### PR TITLE
[Backend-1] Implement jwt create when login and create user

### DIFF
--- a/app/Common/CommonToken.py
+++ b/app/Common/CommonToken.py
@@ -1,0 +1,11 @@
+from fastapi import Response
+
+
+def setResponseRefreshToken(response: Response, refreshToken: str):
+    response.set_cookie(
+        key="refreshToken",
+        value=refreshToken,
+        httponly=True,
+        secure=False, # Only for local dev in production set True
+        samesite="lax" # mb "none" if back and front will on diff domain
+    ) 

--- a/app/api/refreshTokenAPI.py
+++ b/app/api/refreshTokenAPI.py
@@ -1,0 +1,14 @@
+from fastapi import HTTPException, APIRouter, Request
+from auth.jwtHandler import create_access_token, verify_refresh_token
+
+router = APIRouter()
+
+@router.post("/refresh-token")
+async def refresh_token_api(request: Request):
+    try:
+        refreshToken = request.cookies.get("refreshToken")
+        payload = verify_refresh_token(refreshToken)  
+        new_access_token = create_access_token(data={"sub": payload["sub"]})
+        return {"access_token": new_access_token}
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid refresh token. Need ")

--- a/app/api/userAPI.py
+++ b/app/api/userAPI.py
@@ -1,16 +1,25 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.db.dependencyDB import get_db
-from schemas.userShemas import UserCreate, UserOut
+from db.dependencyDB import get_db
+from schemas.userShemas import UserCreate, UserOutWithToken
 from crud.userCRUD import create_user, get_user_by_email
 from auth.jwtHandler import create_access_token, create_refresh_token
+from Common.CommonToken import setResponseRefreshToken
 
 router = APIRouter()
 
-@router.post("/register-common", response_model=UserOut)
-async def create_user_api(user: UserCreate, db: AsyncSession  = Depends(get_db)):
-    return await create_user(user, db)
+@router.post("/register-common", response_model=UserOutWithToken)
+async def create_user_api(user: UserCreate, response: Response, db: AsyncSession  = Depends(get_db)):
+    userId, userOutData = await create_user(user, db)
+    accesToken = create_access_token(data={"sub":str(userId)})
+    refreshToken = create_refresh_token(data={"sub":str(userId)})
+    setResponseRefreshToken(response, refreshToken)
+    return UserOutWithToken(userOutData, accesToken)
 
-@router.post("/login-common", response_model=UserOut)
-async def login_user_api(user: UserCreate, db: AsyncSession  = Depends(get_db)):
-    return await get_user_by_email(user, db)
+@router.post("/login-common", response_model=UserOutWithToken)
+async def login_user_api(user: UserCreate, response: Response, db: AsyncSession  = Depends(get_db)):
+    userId, userOutData = await get_user_by_email(user, db)
+    accesToken = create_access_token(data={"sub":str(userId)})
+    refreshToken = create_refresh_token(data={"sub":str(userId)})
+    setResponseRefreshToken(response, refreshToken)
+    return UserOutWithToken(userOutData, accesToken)

--- a/app/auth/jwtHandler.py
+++ b/app/auth/jwtHandler.py
@@ -1,6 +1,23 @@
 from datetime import datetime, timedelta, timezone
 from jose import jwt, JWTError
+from fastapi import HTTPException
 from config import SECRET_KEY, ACCESS_TOKEN_EXPIRE_MINUTES, ALGORITHM_JWT, REFRESH_TOKEN_EXPIRE_DAYS
+
+def verify_refresh_token(refreshToken: str):
+    try:
+        payload = jwt.decode(
+            refreshToken,
+            SECRET_KEY,
+            algorithms=[ALGORITHM_JWT]
+        )
+        if payload.get("type") != "refresh":
+             raise HTTPException(status_code=401, detail="Invalid token type")
+        
+        return payload
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Refresh token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
 
 def create_access_token(data: dict):
     to_encode = data.copy()

--- a/app/crud/userCRUD.py
+++ b/app/crud/userCRUD.py
@@ -11,7 +11,8 @@ async def create_user(user: UserCreate, db: AsyncSession):
         db.add(db_user)
         await db.commit()
         await db.refresh(db_user)
-        return UserOut.model_validate(db_user)
+        return db_user.id, UserOut.model_validate(db_user)
+    
     except IntegrityError:
         await db.rollback()
         raise HTTPException(
@@ -34,19 +35,13 @@ async def get_user_by_email(user: UserCreate, db: AsyncSession):
         result = await db.execute(stmt)
         existing_user = result.scalar_one_or_none()
 
-        #existing_user = await db.query(UserModel).filter(
-        #   UserModel.email == user.email,
-        #).first()
-        print("existing_user after db req")
-
-        print(existing_user)
         if existing_user.password != user.password:
             raise HTTPException(
                 status_code=404,
                 detail="User not found or incorrect password"
             )
         
-        return UserOut.model_validate(existing_user)
+        return existing_user.id, UserOut.model_validate(existing_user)
         
     except Exception as e:
         raise HTTPException(

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from api import userAPI
+from api import refreshTokenAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
@@ -21,3 +22,4 @@ async def startup():
     print("Server started and wait POST-requests...")
 
 app.include_router(userAPI.router)
+app.include_router(refreshTokenAPI.router)

--- a/app/schemas/userShemas.py
+++ b/app/schemas/userShemas.py
@@ -9,10 +9,14 @@ class UserCreate(BaseModel):
         from_attributes = True
 
 class UserOut(BaseModel):
-    id: int
     email: str
     viewname: Optional[str] = None
     phone_number: Optional[str] = None
 
     class Config:
         from_attributes = True
+
+class UserOutWithToken(BaseModel):
+    userBaseData: UserOut
+    accessToken: str
+


### PR DESCRIPTION
This commit introduces a complete JWT-based authentication flow.

- Adds access and refresh token generation on user login and registration.
- Implements a /refresh-token endpoint to issue new access tokens using the refresh token.
- Secures the refresh token by storing it in an httpOnly cookie, protecting against XSS attacks.
- Returns the access token in the response body for the client to manage.
- Adds a 'type' claim to tokens to distinguish between 'access' and 'refresh'.
- Refactors API responses with a new UserOutWithToken schema.
- Configures CORS to allow credentials for cross-origin cookie handling.
- Creates a helper function to standardize setting the refresh token cookie.